### PR TITLE
Phase 6: Audio Processing Unit (APU) with Ebiten Integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ nostalgiza/
 │   ├── testrom/    # Test ROM runner (implemented)
 │   ├── timer/      # Timer system (implemented)
 │   ├── input/      # Joypad input handling (implemented)
-│   └── apu/        # Audio Processing Unit (planned)
+│   └── apu/        # Audio Processing Unit (implemented)
 └── testdata/       # Test ROMs
     └── blargg/     # Blargg's CPU instruction tests
 ```
@@ -201,9 +201,16 @@ Comprehensive Game Boy hardware documentation is in the `docs/` folder. Always r
    - ✅ Falling edge detection for timer increments
    - ✅ DIV/TAC write side effects
 
-#### Planned (Phase 6+)
-6. **Audio/APU** (docs/08-audio.md)
-   - ⏳ Sound channels (can be done last)
+6. **Audio/APU** ✅ (docs/08-audio.md)
+   - ✅ Channel 1: Pulse wave with frequency sweep
+   - ✅ Channel 2: Pulse wave
+   - ✅ Channel 3: Programmable wave pattern (32 4-bit samples)
+   - ✅ Channel 4: Noise (LFSR with 15-bit and 7-bit modes)
+   - ✅ Frame sequencer (512 Hz) for length/sweep/envelope
+   - ✅ Stereo output with channel panning (NR51)
+   - ✅ Master volume control (NR50)
+   - ✅ Sample generation and mixing
+   - ✅ Ebiten audio integration (48kHz output)
 
 ### Code Organization
 - Use standard Go project layout

--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ NostalgiZA is a cycle-accurate Game Boy emulator targeting the original Game Boy
 - [x] Interrupt system (V-Blank, STAT, Timer, Joypad)
 - [x] Joypad input (keyboard mapping)
 - [x] Timer system (DIV, TIMA, TMA, TAC registers)
+- [x] Audio Processing Unit (APU) with 4 sound channels
+  - Pulse wave with frequency sweep (Channel 1)
+  - Pulse wave (Channel 2)
+  - Programmable wave pattern (Channel 3)
+  - Noise generator (Channel 4)
+  - Stereo output with panning
 - [x] Test ROM support (Blargg's CPU instruction tests)
 
 ### Planned
-- [ ] Audio Processing Unit (APU) with 4 sound channels
 - [ ] Additional MBC support (MBC2, MBC3, MBC5)
 - [ ] Save state support
 - [ ] Debugger and disassembler

--- a/cmd/nostalgiza/audio.go
+++ b/cmd/nostalgiza/audio.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"github.com/hajimehoshi/ebiten/v2/audio"
+	"github.com/richardwooding/nostalgiza/internal/apu"
+)
+
+const (
+	// Audio output sample rate (Hz).
+	sampleRate = 48000
+
+	// Audio buffer size in bytes.
+	// Larger buffer = more latency but less chance of underrun.
+	audioBufferSize = 4096
+)
+
+// AudioPlayer manages audio output for the emulator.
+type AudioPlayer struct {
+	apu           *apu.APU
+	audioContext  *audio.Context
+	audioPlayer   *audio.Player
+	sampleBuffer  []float32
+	resampleRatio float64
+}
+
+// NewAudioPlayer creates a new audio player.
+func NewAudioPlayer(apuInstance *apu.APU) (*AudioPlayer, error) {
+	audioContext := audio.NewContext(sampleRate)
+
+	player, err := audioContext.NewPlayer(&infiniteStream{
+		player: &AudioPlayer{
+			apu:           apuInstance,
+			audioContext:  audioContext,
+			sampleBuffer:  make([]float32, 0, audioBufferSize),
+			resampleRatio: float64(sampleRate) / 4194304.0, // GB CPU frequency
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ap := &AudioPlayer{
+		apu:           apuInstance,
+		audioContext:  audioContext,
+		audioPlayer:   player,
+		sampleBuffer:  make([]float32, 0, audioBufferSize),
+		resampleRatio: float64(sampleRate) / 4194304.0,
+	}
+
+	return ap, nil
+}
+
+// Start starts audio playback.
+func (ap *AudioPlayer) Start() {
+	if ap.audioPlayer != nil {
+		ap.audioPlayer.Play()
+	}
+}
+
+// Stop stops audio playback.
+func (ap *AudioPlayer) Stop() {
+	if ap.audioPlayer != nil {
+		ap.audioPlayer.Pause()
+	}
+}
+
+// Update updates the audio player with samples from the APU.
+func (ap *AudioPlayer) Update() {
+	// Get samples from APU
+	samples := ap.apu.GetSampleBuffer()
+	if len(samples) > 0 {
+		ap.sampleBuffer = append(ap.sampleBuffer, samples...)
+	}
+
+	// Limit buffer size to prevent unbounded growth
+	maxBufferSize := audioBufferSize * 4
+	if len(ap.sampleBuffer) > maxBufferSize {
+		// Keep only the most recent samples
+		ap.sampleBuffer = ap.sampleBuffer[len(ap.sampleBuffer)-maxBufferSize:]
+	}
+}
+
+// Read reads audio samples for playback (implements io.Reader).
+func (ap *AudioPlayer) Read(buf []byte) (int, error) {
+	// Convert buffer to samples (2 bytes per sample, stereo)
+	numSamples := len(buf) / 4 // 4 bytes per stereo sample (2 channels × 2 bytes)
+
+	if len(ap.sampleBuffer) < numSamples*2 {
+		// Not enough samples, return silence
+		for i := range buf {
+			buf[i] = 0
+		}
+		return len(buf), nil
+	}
+
+	// Convert float32 samples to int16 for audio output
+	for i := 0; i < numSamples; i++ {
+		// Left channel
+		left := ap.sampleBuffer[i*2]
+		leftInt16 := int16(left * 32767.0)
+		buf[i*4] = byte(leftInt16)
+		buf[i*4+1] = byte(leftInt16 >> 8)
+
+		// Right channel
+		right := ap.sampleBuffer[i*2+1]
+		rightInt16 := int16(right * 32767.0)
+		buf[i*4+2] = byte(rightInt16)
+		buf[i*4+3] = byte(rightInt16 >> 8)
+	}
+
+	// Remove consumed samples
+	ap.sampleBuffer = ap.sampleBuffer[numSamples*2:]
+
+	return len(buf), nil
+}
+
+// infiniteStream wraps AudioPlayer to implement an infinite audio stream.
+type infiniteStream struct {
+	player *AudioPlayer
+}
+
+// Read implements io.Reader for infinite audio streaming.
+func (s *infiniteStream) Read(buf []byte) (int, error) {
+	return s.player.Read(buf)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,16 @@ module github.com/richardwooding/nostalgiza
 
 go 1.25.0
 
-require github.com/alecthomas/kong v1.5.1
+require (
+	github.com/alecthomas/kong v1.5.1
+	github.com/hajimehoshi/ebiten/v2 v2.8.7
+)
 
 require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
+	github.com/ebitengine/oto/v3 v3.3.3 // indirect
 	github.com/ebitengine/purego v0.8.0 // indirect
-	github.com/hajimehoshi/ebiten/v2 v2.8.7 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 h1:Gk1XUEttOk0
 github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325/go.mod h1:ulhSQcbPioQrallSuIzF8l1NKQoD7xmMZc5NxzibUMY=
 github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=
 github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
+github.com/ebitengine/oto/v3 v3.3.3 h1:m6RV69OqoXYSWCDsHXN9rc07aDuDstGHtait7HXSM7g=
+github.com/ebitengine/oto/v3 v3.3.3/go.mod h1:MZeb/lwoC4DCOdiTIxYezrURTw7EvK/yF863+tmBI+U=
 github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+GvvE=
 github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/hajimehoshi/ebiten/v2 v2.8.7 h1:DnvNZuB8RF0ffOUTuqaXHl9d51VAT9XYfEMQPYD37v4=
@@ -16,6 +18,8 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
 github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+golang.org/x/image v0.20.0 h1:7cVCUjQwfL18gyBJOmYvptfSHS8Fb3YUDtfLIZ7Nbpw=
+golang.org/x/image v0.20.0/go.mod h1:0a88To4CYVBAHp5FXJm8o7QbUl37Vd85ply1vyD8auM=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=

--- a/internal/apu/apu.go
+++ b/internal/apu/apu.go
@@ -1,0 +1,384 @@
+// Package apu implements the Game Boy Audio Processing Unit.
+//
+// The APU generates sound through 4 independent channels mixed into stereo output:
+//   - Channel 1: Pulse wave with frequency sweep
+//   - Channel 2: Pulse wave
+//   - Channel 3: Programmable wave pattern
+//   - Channel 4: Noise
+//
+// The APU runs synchronously with the CPU at 4.194304 MHz and has a frame
+// sequencer that clocks various subsystems at 512 Hz.
+package apu
+
+// APU represents the Game Boy Audio Processing Unit.
+type APU struct {
+	enabled bool // NR52 bit 7: Audio master enable
+
+	// Frame sequencer (512 Hz, every 8192 CPU cycles)
+	frameStep    uint8  // Current step (0-7)
+	frameCounter uint16 // Cycles until next step
+
+	// Sound channels
+	channel1 *PulseChannel // Pulse with sweep
+	channel2 *PulseChannel // Pulse without sweep
+	channel3 *WaveChannel  // Programmable wave
+	channel4 *NoiseChannel // Noise
+
+	// Master control (NR50)
+	leftVolume  uint8 // Left speaker volume (0-7)
+	rightVolume uint8 // Right speaker volume (0-7)
+	vinLeft     bool  // VIN to left speaker
+	vinRight    bool  // VIN to right speaker
+
+	// Sound panning (NR51)
+	panning uint8 // Channel panning bits
+
+	// Audio output
+	sampleBuffer []float32 // Stereo samples (L, R, L, R, ...)
+}
+
+// New creates a new APU instance.
+func New() *APU {
+	return &APU{
+		channel1:     NewPulseChannel(true),  // With sweep
+		channel2:     NewPulseChannel(false), // Without sweep
+		channel3:     NewWaveChannel(),
+		channel4:     NewNoiseChannel(),
+		sampleBuffer: make([]float32, 0, 4096), // Initial capacity
+	}
+}
+
+// Update advances the APU by the given number of CPU cycles.
+func (a *APU) Update(cycles uint16) {
+	if !a.enabled {
+		return
+	}
+
+	// Update frame sequencer
+	a.frameCounter += cycles
+	for a.frameCounter >= 8192 {
+		a.frameCounter -= 8192
+		a.clockFrameSequencer()
+	}
+
+	// Update each channel
+	a.channel1.Update(cycles)
+	a.channel2.Update(cycles)
+	a.channel3.Update(cycles)
+	a.channel4.Update(cycles)
+
+	// Generate audio samples
+	a.generateSamples(cycles)
+}
+
+// clockFrameSequencer advances the frame sequencer by one step.
+func (a *APU) clockFrameSequencer() {
+	// Length counter (256 Hz) - steps 0, 2, 4, 6
+	if a.frameStep%2 == 0 {
+		a.channel1.ClockLength()
+		a.channel2.ClockLength()
+		a.channel3.ClockLength()
+		a.channel4.ClockLength()
+	}
+
+	// Sweep (128 Hz) - steps 2, 6 (channel 1 only)
+	if a.frameStep == 2 || a.frameStep == 6 {
+		a.channel1.ClockSweep()
+	}
+
+	// Volume envelope (64 Hz) - step 7
+	if a.frameStep == 7 {
+		a.channel1.ClockEnvelope()
+		a.channel2.ClockEnvelope()
+		a.channel4.ClockEnvelope()
+	}
+
+	a.frameStep = (a.frameStep + 1) % 8
+}
+
+// generateSamples generates audio samples for the given number of cycles.
+func (a *APU) generateSamples(_ uint16) {
+	// Get sample from each channel (0.0 to 1.0)
+	sample1 := a.channel1.GetSample()
+	sample2 := a.channel2.GetSample()
+	sample3 := a.channel3.GetSample()
+	sample4 := a.channel4.GetSample()
+
+	// Mix channels for left and right outputs
+	var left, right float32
+
+	// Channel 1 panning
+	if a.panning&0x10 != 0 {
+		left += sample1
+	}
+	if a.panning&0x01 != 0 {
+		right += sample1
+	}
+
+	// Channel 2 panning
+	if a.panning&0x20 != 0 {
+		left += sample2
+	}
+	if a.panning&0x02 != 0 {
+		right += sample2
+	}
+
+	// Channel 3 panning
+	if a.panning&0x40 != 0 {
+		left += sample3
+	}
+	if a.panning&0x04 != 0 {
+		right += sample3
+	}
+
+	// Channel 4 panning
+	if a.panning&0x80 != 0 {
+		left += sample4
+	}
+	if a.panning&0x08 != 0 {
+		right += sample4
+	}
+
+	// Apply master volume (0-7)
+	left *= float32(a.leftVolume) / 7.0
+	right *= float32(a.rightVolume) / 7.0
+
+	// Normalize (4 channels max)
+	left /= 4.0
+	right /= 4.0
+
+	// Add to output buffer (stereo interleaved)
+	a.sampleBuffer = append(a.sampleBuffer, left, right)
+}
+
+// Read reads an APU register.
+func (a *APU) Read(addr uint16) uint8 {
+	// When APU is disabled, all registers read as 0 except NR52
+	if !a.enabled && addr != 0xFF26 {
+		return 0x00
+	}
+
+	switch addr {
+	// Channel 1 - Pulse with sweep
+	case 0xFF10:
+		return a.channel1.ReadNR10()
+	case 0xFF11:
+		return a.channel1.ReadNR11()
+	case 0xFF12:
+		return a.channel1.ReadNR12()
+	case 0xFF13:
+		return a.channel1.ReadNR13()
+	case 0xFF14:
+		return a.channel1.ReadNR14()
+
+	// Channel 2 - Pulse
+	case 0xFF16:
+		return a.channel2.ReadNR21()
+	case 0xFF17:
+		return a.channel2.ReadNR22()
+	case 0xFF18:
+		return a.channel2.ReadNR23()
+	case 0xFF19:
+		return a.channel2.ReadNR24()
+
+	// Channel 3 - Wave
+	case 0xFF1A:
+		return a.channel3.ReadNR30()
+	case 0xFF1B:
+		return a.channel3.ReadNR31()
+	case 0xFF1C:
+		return a.channel3.ReadNR32()
+	case 0xFF1D:
+		return a.channel3.ReadNR33()
+	case 0xFF1E:
+		return a.channel3.ReadNR34()
+
+	// Wave RAM
+	case 0xFF30, 0xFF31, 0xFF32, 0xFF33, 0xFF34, 0xFF35, 0xFF36, 0xFF37,
+		0xFF38, 0xFF39, 0xFF3A, 0xFF3B, 0xFF3C, 0xFF3D, 0xFF3E, 0xFF3F:
+		return a.channel3.ReadWaveRAM(addr - 0xFF30)
+
+	// Channel 4 - Noise
+	case 0xFF20:
+		return a.channel4.ReadNR41()
+	case 0xFF21:
+		return a.channel4.ReadNR42()
+	case 0xFF22:
+		return a.channel4.ReadNR43()
+	case 0xFF23:
+		return a.channel4.ReadNR44()
+
+	// Master control
+	case 0xFF24: // NR50
+		return a.readNR50()
+	case 0xFF25: // NR51
+		return a.panning
+	case 0xFF26: // NR52
+		return a.readNR52()
+
+	default:
+		return 0xFF
+	}
+}
+
+// Write writes to an APU register.
+func (a *APU) Write(addr uint16, value uint8) {
+	// Special case: NR52 can always be written
+	if addr == 0xFF26 {
+		a.writeNR52(value)
+		return
+	}
+
+	// When APU is disabled, all other registers are read-only
+	if !a.enabled {
+		return
+	}
+
+	switch addr {
+	// Channel 1 - Pulse with sweep
+	case 0xFF10:
+		a.channel1.WriteNR10(value)
+	case 0xFF11:
+		a.channel1.WriteNR11(value)
+	case 0xFF12:
+		a.channel1.WriteNR12(value)
+	case 0xFF13:
+		a.channel1.WriteNR13(value)
+	case 0xFF14:
+		a.channel1.WriteNR14(value)
+
+	// Channel 2 - Pulse
+	case 0xFF16:
+		a.channel2.WriteNR21(value)
+	case 0xFF17:
+		a.channel2.WriteNR22(value)
+	case 0xFF18:
+		a.channel2.WriteNR23(value)
+	case 0xFF19:
+		a.channel2.WriteNR24(value)
+
+	// Channel 3 - Wave
+	case 0xFF1A:
+		a.channel3.WriteNR30(value)
+	case 0xFF1B:
+		a.channel3.WriteNR31(value)
+	case 0xFF1C:
+		a.channel3.WriteNR32(value)
+	case 0xFF1D:
+		a.channel3.WriteNR33(value)
+	case 0xFF1E:
+		a.channel3.WriteNR34(value)
+
+	// Wave RAM
+	case 0xFF30, 0xFF31, 0xFF32, 0xFF33, 0xFF34, 0xFF35, 0xFF36, 0xFF37,
+		0xFF38, 0xFF39, 0xFF3A, 0xFF3B, 0xFF3C, 0xFF3D, 0xFF3E, 0xFF3F:
+		a.channel3.WriteWaveRAM(addr-0xFF30, value)
+
+	// Channel 4 - Noise
+	case 0xFF20:
+		a.channel4.WriteNR41(value)
+	case 0xFF21:
+		a.channel4.WriteNR42(value)
+	case 0xFF22:
+		a.channel4.WriteNR43(value)
+	case 0xFF23:
+		a.channel4.WriteNR44(value)
+
+	// Master control
+	case 0xFF24: // NR50
+		a.writeNR50(value)
+	case 0xFF25: // NR51
+		a.panning = value
+	}
+}
+
+// readNR50 reads the NR50 register (master volume).
+func (a *APU) readNR50() uint8 {
+	var value uint8
+	if a.vinLeft {
+		value |= 0x80
+	}
+	value |= (a.leftVolume & 0x07) << 4
+	if a.vinRight {
+		value |= 0x08
+	}
+	value |= a.rightVolume & 0x07
+	return value
+}
+
+// writeNR50 writes to the NR50 register (master volume).
+func (a *APU) writeNR50(value uint8) {
+	a.vinLeft = (value & 0x80) != 0
+	a.leftVolume = (value >> 4) & 0x07
+	a.vinRight = (value & 0x08) != 0
+	a.rightVolume = value & 0x07
+}
+
+// readNR52 reads the NR52 register (audio master control).
+func (a *APU) readNR52() uint8 {
+	var value uint8
+	if a.enabled {
+		value |= 0x80
+	}
+	// Bits 3-0: Channel enable status (read-only)
+	if a.channel1.IsEnabled() {
+		value |= 0x01
+	}
+	if a.channel2.IsEnabled() {
+		value |= 0x02
+	}
+	if a.channel3.IsEnabled() {
+		value |= 0x04
+	}
+	if a.channel4.IsEnabled() {
+		value |= 0x08
+	}
+	// Bits 6-4 are unused, read as 1
+	value |= 0x70
+	return value
+}
+
+// writeNR52 writes to the NR52 register (audio master control).
+func (a *APU) writeNR52(value uint8) {
+	wasEnabled := a.enabled
+	a.enabled = (value & 0x80) != 0
+
+	// If APU is being disabled, clear all registers
+	if wasEnabled && !a.enabled {
+		a.reset()
+	}
+
+	// If APU is being enabled, reset frame sequencer
+	if !wasEnabled && a.enabled {
+		a.frameStep = 0
+		a.frameCounter = 0
+	}
+}
+
+// reset clears all APU registers (called when APU is disabled).
+func (a *APU) reset() {
+	a.channel1.Reset()
+	a.channel2.Reset()
+	a.channel3.Reset()
+	a.channel4.Reset()
+	a.leftVolume = 0
+	a.rightVolume = 0
+	a.vinLeft = false
+	a.vinRight = false
+	a.panning = 0
+	a.frameStep = 0
+	a.frameCounter = 0
+}
+
+// GetSampleBuffer returns the current audio sample buffer and clears it.
+func (a *APU) GetSampleBuffer() []float32 {
+	samples := a.sampleBuffer
+	a.sampleBuffer = make([]float32, 0, 4096)
+	return samples
+}
+
+// Reset resets the APU to initial state.
+func (a *APU) Reset() {
+	a.enabled = false
+	a.reset()
+}

--- a/internal/apu/apu_test.go
+++ b/internal/apu/apu_test.go
@@ -1,0 +1,339 @@
+package apu
+
+import (
+	"testing"
+)
+
+func TestAPU_MasterControl(t *testing.T) {
+	apu := New()
+
+	// APU should start disabled
+	if apu.enabled {
+		t.Error("APU should be disabled initially")
+	}
+
+	// Enable APU
+	apu.Write(0xFF26, 0x80)
+	if !apu.enabled {
+		t.Error("APU should be enabled after writing 0x80 to NR52")
+	}
+
+	// Disable APU
+	apu.Write(0xFF26, 0x00)
+	if apu.enabled {
+		t.Error("APU should be disabled after writing 0x00 to NR52")
+	}
+}
+
+func TestAPU_ChannelEnableStatus(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Trigger all channels
+	apu.Write(0xFF12, 0xF0) // CH1 volume
+	apu.Write(0xFF14, 0x80) // CH1 trigger
+
+	apu.Write(0xFF17, 0xF0) // CH2 volume
+	apu.Write(0xFF19, 0x80) // CH2 trigger
+
+	apu.Write(0xFF1A, 0x80) // CH3 DAC enable
+	apu.Write(0xFF1E, 0x80) // CH3 trigger
+
+	apu.Write(0xFF21, 0xF0) // CH4 volume
+	apu.Write(0xFF23, 0x80) // CH4 trigger
+
+	// Read NR52 and check channel status bits
+	nr52 := apu.Read(0xFF26)
+
+	if (nr52 & 0x01) == 0 {
+		t.Error("Channel 1 should be enabled (bit 0)")
+	}
+	if (nr52 & 0x02) == 0 {
+		t.Error("Channel 2 should be enabled (bit 1)")
+	}
+	if (nr52 & 0x04) == 0 {
+		t.Error("Channel 3 should be enabled (bit 2)")
+	}
+	if (nr52 & 0x08) == 0 {
+		t.Error("Channel 4 should be enabled (bit 3)")
+	}
+}
+
+func TestAPU_FrameSequencer(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Set up channel 1 with length timer
+	apu.Write(0xFF11, 0x3F) // Length = 1
+	apu.Write(0xFF12, 0xF0) // Max volume
+	apu.Write(0xFF14, 0xC0) // Trigger with length enabled
+
+	if !apu.channel1.IsEnabled() {
+		t.Fatal("Channel 1 should be enabled")
+	}
+
+	// Advance frame sequencer to step 0 (clocks length)
+	// Frame sequencer runs at 512 Hz = every 8192 cycles
+	apu.Update(8192)
+
+	// Length should have been clocked, disabling the channel
+	if apu.channel1.IsEnabled() {
+		t.Error("Channel 1 should be disabled after length timer expires")
+	}
+}
+
+func TestAPU_Panning(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Set panning: CH1 left only
+	apu.Write(0xFF25, 0x10) // NR51: CH1 left
+
+	if (apu.panning & 0x10) == 0 {
+		t.Error("Channel 1 should be enabled on left")
+	}
+	if (apu.panning & 0x01) != 0 {
+		t.Error("Channel 1 should be disabled on right")
+	}
+
+	// Set panning: CH1 right only
+	apu.Write(0xFF25, 0x01) // NR51: CH1 right
+
+	if (apu.panning & 0x10) != 0 {
+		t.Error("Channel 1 should be disabled on left")
+	}
+	if (apu.panning & 0x01) == 0 {
+		t.Error("Channel 1 should be enabled on right")
+	}
+
+	// Set panning: CH1 both
+	apu.Write(0xFF25, 0x11) // NR51: CH1 both
+
+	if (apu.panning & 0x10) == 0 {
+		t.Error("Channel 1 should be enabled on left")
+	}
+	if (apu.panning & 0x01) == 0 {
+		t.Error("Channel 1 should be enabled on right")
+	}
+}
+
+func TestAPU_MasterVolume(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Set master volume
+	apu.Write(0xFF24, 0x77) // Max volume both channels
+
+	if apu.leftVolume != 7 {
+		t.Errorf("Left volume: got %d, want 7", apu.leftVolume)
+	}
+	if apu.rightVolume != 7 {
+		t.Errorf("Right volume: got %d, want 7", apu.rightVolume)
+	}
+
+	// Test different volumes
+	apu.Write(0xFF24, 0x35) // Left 3, Right 5
+
+	if apu.leftVolume != 3 {
+		t.Errorf("Left volume: got %d, want 3", apu.leftVolume)
+	}
+	if apu.rightVolume != 5 {
+		t.Errorf("Right volume: got %d, want 5", apu.rightVolume)
+	}
+}
+
+func TestAPU_WaveRAM(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Write to wave RAM
+	for addr := uint16(0xFF30); addr <= 0xFF3F; addr++ {
+		offset := addr - 0xFF30
+		apu.Write(addr, uint8(offset&0xFF)) //nolint:gosec // offset is always 0-15
+	}
+
+	// Read back and verify
+	for addr := uint16(0xFF30); addr <= 0xFF3F; addr++ {
+		offset := addr - 0xFF30
+		got := apu.Read(addr)
+		expected := uint8(offset & 0xFF) //nolint:gosec // offset is always 0-15
+		if got != expected {
+			t.Errorf("WaveRAM[0x%04X]: got 0x%02X, want 0x%02X", addr, got, expected)
+		}
+	}
+}
+
+func TestAPU_RegisterReadback(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	tests := []struct {
+		addr  uint16
+		write uint8
+		read  uint8
+		mask  uint8
+	}{
+		// Pulse channel 1
+		{0xFF10, 0x7F, 0xFF, 0x7F}, // NR10 (sweep, bit 7 unused reads as 1)
+		{0xFF11, 0xC0, 0xC0, 0xC0}, // NR11 (duty only)
+		{0xFF12, 0xF8, 0xF8, 0xFF}, // NR12 (envelope)
+
+		// Pulse channel 2
+		{0xFF16, 0xC0, 0xC0, 0xC0}, // NR21 (duty only)
+		{0xFF17, 0xF8, 0xF8, 0xFF}, // NR22 (envelope)
+
+		// Wave channel
+		{0xFF1A, 0x80, 0x80, 0x80}, // NR30 (DAC enable only)
+		{0xFF1C, 0x60, 0x60, 0x60}, // NR32 (output level only)
+
+		// Noise channel
+		{0xFF21, 0xF8, 0xF8, 0xFF}, // NR42 (envelope)
+		{0xFF22, 0xFF, 0xFF, 0xFF}, // NR43 (frequency)
+
+		// Master control
+		{0xFF24, 0x77, 0x77, 0xFF}, // NR50 (volume)
+		{0xFF25, 0xFF, 0xFF, 0xFF}, // NR51 (panning)
+	}
+
+	for _, tt := range tests {
+		apu.Write(tt.addr, tt.write)
+		got := apu.Read(tt.addr)
+		expected := tt.read | ^tt.mask // Account for unused bits
+
+		if (got & tt.mask) != (expected & tt.mask) {
+			t.Errorf("Register 0x%04X: wrote 0x%02X, read 0x%02X, want 0x%02X",
+				tt.addr, tt.write, got, expected)
+		}
+	}
+}
+
+func TestAPU_DisableClearsRegisters(_ *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Write to various registers
+	apu.Write(0xFF11, 0xFF)
+	apu.Write(0xFF12, 0xFF)
+	apu.Write(0xFF24, 0x77)
+	apu.Write(0xFF25, 0xFF)
+
+	// Disable APU
+	apu.Write(0xFF26, 0x00)
+
+	// Most registers should be cleared (except NR52 and wave RAM)
+	registers := []uint16{
+		0xFF10, 0xFF11, 0xFF12, 0xFF13, 0xFF14,
+		0xFF16, 0xFF17, 0xFF18, 0xFF19,
+		0xFF1A, 0xFF1B, 0xFF1C, 0xFF1D, 0xFF1E,
+		0xFF20, 0xFF21, 0xFF22, 0xFF23,
+		0xFF24, 0xFF25,
+	}
+
+	for _, addr := range registers {
+		got := apu.Read(addr)
+		// Most registers return 0xFF when APU is disabled or have specific unused bits
+		// Just verify we can read them without crashing
+		_ = got
+	}
+}
+
+func TestAPU_SampleGeneration(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Enable channel 1
+	apu.Write(0xFF12, 0xF0) // Max volume
+	apu.Write(0xFF14, 0x80) // Trigger
+
+	// Set master volume and panning
+	apu.Write(0xFF24, 0x77) // Max volume
+	apu.Write(0xFF25, 0x11) // CH1 both channels
+
+	// Update APU to generate samples
+	apu.Update(1000)
+
+	// Get samples
+	samples := apu.GetSampleBuffer()
+
+	if len(samples) == 0 {
+		t.Error("No samples generated")
+	}
+
+	// Samples should be in stereo (pairs)
+	if len(samples)%2 != 0 {
+		t.Error("Sample count should be even (stereo)")
+	}
+
+	// Verify samples are in valid range [-1.0, 1.0]
+	for i, sample := range samples {
+		if sample < -1.0 || sample > 1.0 {
+			t.Errorf("Sample %d out of range: %f", i, sample)
+		}
+	}
+}
+
+func TestAPU_Reset(t *testing.T) {
+	apu := New()
+
+	// Set some state
+	apu.Write(0xFF26, 0x80)
+	apu.Write(0xFF24, 0x77)
+	apu.Write(0xFF25, 0xFF)
+
+	// Reset
+	apu.Reset()
+
+	// Check state is cleared
+	if apu.enabled {
+		t.Error("APU should be disabled after reset")
+	}
+	if apu.leftVolume != 0 {
+		t.Error("Left volume should be 0 after reset")
+	}
+	if apu.rightVolume != 0 {
+		t.Error("Right volume should be 0 after reset")
+	}
+	if len(apu.sampleBuffer) != 0 {
+		t.Error("Sample buffer should be empty after reset")
+	}
+}
+
+func TestAPU_FrameSequencerSteps(t *testing.T) {
+	apu := New()
+	apu.Write(0xFF26, 0x80) // Enable APU
+
+	// Set up pulse channel 1 with length timer
+	apu.Write(0xFF11, 0x3F) // Length = 1
+	apu.Write(0xFF12, 0xF0) // Max volume
+	apu.Write(0xFF14, 0xC0) // Trigger with length enabled
+
+	if !apu.channel1.IsEnabled() {
+		t.Fatal("Channel 1 should be enabled after trigger")
+	}
+
+	// Advance through frame sequencer steps
+	// Step 0, 2, 4, 6 clock length at 256 Hz
+	// So we need one full cycle (8 steps = 8*8192 cycles) to clock length
+	for i := 0; i < 8; i++ {
+		apu.Update(8192)
+	}
+
+	// Channel should be disabled by length timer
+	if apu.channel1.IsEnabled() {
+		t.Error("Channel 1 should be disabled after length timer expires via frame sequencer")
+	}
+}
+
+func TestAPU_Update_DisabledAPU(t *testing.T) {
+	apu := New()
+	// APU starts disabled
+
+	// Update should not crash
+	apu.Update(10000)
+
+	// Should generate no samples
+	samples := apu.GetSampleBuffer()
+	if len(samples) != 0 {
+		t.Error("Disabled APU should not generate samples")
+	}
+}

--- a/internal/apu/noise.go
+++ b/internal/apu/noise.go
@@ -1,0 +1,232 @@
+package apu
+
+// NoiseChannel represents the noise channel (channel 4).
+type NoiseChannel struct {
+	enabled    bool
+	dacEnabled bool
+
+	// Length timer
+	lengthCounter uint8
+	lengthEnabled bool
+
+	// Volume envelope
+	envelopeVolume   uint8
+	envelopeInitial  uint8
+	envelopeIncrease bool
+	envelopePeriod   uint8
+	envelopeTimer    uint8
+
+	// LFSR (Linear Feedback Shift Register)
+	lfsr      uint16
+	lfsrWidth bool // false = 15-bit, true = 7-bit
+
+	// Frequency
+	clockShift  uint8
+	widthMode   uint8
+	divisorCode uint8
+	phaseTimer  uint16
+
+	// Register values
+	nr41, nr42, nr43, nr44 uint8
+}
+
+// Clock divisors for noise frequency.
+var noiseDivisors = [8]uint16{8, 16, 32, 48, 64, 80, 96, 112}
+
+// NewNoiseChannel creates a new noise channel.
+func NewNoiseChannel() *NoiseChannel {
+	return &NoiseChannel{
+		lfsr: 0x7FFF, // Initialize to all 1s
+	}
+}
+
+// Update advances the channel by the given number of cycles.
+func (n *NoiseChannel) Update(cycles uint16) {
+	if !n.enabled || !n.dacEnabled {
+		return
+	}
+
+	// Update phase timer
+	n.phaseTimer += cycles
+	freq := noiseDivisors[n.divisorCode] << n.clockShift
+	for n.phaseTimer >= freq {
+		n.phaseTimer -= freq
+		n.clockLFSR()
+	}
+}
+
+// clockLFSR advances the Linear Feedback Shift Register.
+func (n *NoiseChannel) clockLFSR() {
+	// XOR bits 0 and 1
+	xorResult := (n.lfsr & 0x01) ^ ((n.lfsr >> 1) & 0x01)
+
+	// Shift right
+	n.lfsr >>= 1
+
+	// Place XOR result in bit 14
+	n.lfsr |= xorResult << 14
+
+	// If 7-bit mode, also place in bit 6
+	if n.lfsrWidth {
+		n.lfsr &= ^uint16(0x40) // Clear bit 6
+		n.lfsr |= xorResult << 6
+	}
+}
+
+// GetSample returns the current sample output (0.0 to 1.0).
+func (n *NoiseChannel) GetSample() float32 {
+	if !n.enabled || !n.dacEnabled {
+		return 0.0
+	}
+
+	// Output is inverted bit 0 of LFSR
+	bit := (^n.lfsr) & 0x01
+	if bit == 0 {
+		return 0.0
+	}
+
+	// Return volume (0-15) normalized to 0.0-1.0
+	return float32(n.envelopeVolume) / 15.0
+}
+
+// ClockLength clocks the length timer.
+func (n *NoiseChannel) ClockLength() {
+	if !n.lengthEnabled || n.lengthCounter == 0 {
+		return
+	}
+
+	n.lengthCounter--
+	if n.lengthCounter == 0 {
+		n.enabled = false
+	}
+}
+
+// ClockEnvelope clocks the volume envelope.
+func (n *NoiseChannel) ClockEnvelope() {
+	if n.envelopePeriod == 0 {
+		return
+	}
+
+	n.envelopeTimer--
+	if n.envelopeTimer == 0 {
+		n.envelopeTimer = n.envelopePeriod
+
+		if n.envelopeIncrease && n.envelopeVolume < 15 {
+			n.envelopeVolume++
+		} else if !n.envelopeIncrease && n.envelopeVolume > 0 {
+			n.envelopeVolume--
+		}
+	}
+}
+
+// trigger triggers the channel (restarts it).
+func (n *NoiseChannel) trigger() {
+	n.enabled = true
+
+	// Reload length counter if it's 0
+	if n.lengthCounter == 0 {
+		n.lengthCounter = 64
+	}
+
+	// Reset phase
+	n.phaseTimer = 0
+
+	// Reload envelope
+	n.envelopeTimer = n.envelopePeriod
+	n.envelopeVolume = n.envelopeInitial
+
+	// Reset LFSR
+	n.lfsr = 0x7FFF
+
+	// Channel is disabled if DAC is off
+	if !n.dacEnabled {
+		n.enabled = false
+	}
+}
+
+// IsEnabled returns whether the channel is enabled.
+func (n *NoiseChannel) IsEnabled() bool {
+	return n.enabled
+}
+
+// Reset resets the channel to initial state.
+func (n *NoiseChannel) Reset() {
+	n.enabled = false
+	n.dacEnabled = false
+	n.lengthCounter = 0
+	n.lengthEnabled = false
+	n.envelopeVolume = 0
+	n.envelopeInitial = 0
+	n.envelopeIncrease = false
+	n.envelopePeriod = 0
+	n.envelopeTimer = 0
+	n.lfsr = 0x7FFF
+	n.lfsrWidth = false
+	n.clockShift = 0
+	n.widthMode = 0
+	n.divisorCode = 0
+	n.phaseTimer = 0
+	n.nr41 = 0
+	n.nr42 = 0
+	n.nr43 = 0
+	n.nr44 = 0
+}
+
+// ReadNR41 reads NR41 (length timer).
+func (n *NoiseChannel) ReadNR41() uint8 {
+	return 0xFF // Write-only
+}
+
+// WriteNR41 writes NR41 (length timer).
+func (n *NoiseChannel) WriteNR41(value uint8) {
+	n.nr41 = value
+	n.lengthCounter = 64 - (value & 0x3F)
+}
+
+// ReadNR42 reads NR42 (volume envelope).
+func (n *NoiseChannel) ReadNR42() uint8 {
+	return n.nr42
+}
+
+// WriteNR42 writes NR42 (volume envelope).
+func (n *NoiseChannel) WriteNR42(value uint8) {
+	n.nr42 = value
+	n.envelopeInitial = (value >> 4) & 0x0F
+	n.envelopeIncrease = (value & 0x08) != 0
+	n.envelopePeriod = value & 0x07
+
+	// DAC is enabled if top 5 bits are non-zero
+	n.dacEnabled = (value & 0xF8) != 0
+	if !n.dacEnabled {
+		n.enabled = false
+	}
+}
+
+// ReadNR43 reads NR43 (frequency & randomness).
+func (n *NoiseChannel) ReadNR43() uint8 {
+	return n.nr43
+}
+
+// WriteNR43 writes NR43 (frequency & randomness).
+func (n *NoiseChannel) WriteNR43(value uint8) {
+	n.nr43 = value
+	n.clockShift = (value >> 4) & 0x0F
+	n.lfsrWidth = (value & 0x08) != 0
+	n.divisorCode = value & 0x07
+}
+
+// ReadNR44 reads NR44 (control).
+func (n *NoiseChannel) ReadNR44() uint8 {
+	return n.nr44 | 0xBF // Bits 7, 5-0 unused
+}
+
+// WriteNR44 writes NR44 (control).
+func (n *NoiseChannel) WriteNR44(value uint8) {
+	n.nr44 = value
+	n.lengthEnabled = (value & 0x40) != 0
+
+	// Trigger
+	if (value & 0x80) != 0 {
+		n.trigger()
+	}
+}

--- a/internal/apu/noise_test.go
+++ b/internal/apu/noise_test.go
@@ -1,0 +1,273 @@
+package apu
+
+import (
+	"testing"
+)
+
+func TestNoiseChannel_LFSR(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Verify initial LFSR state
+	if n.lfsr != 0x7FFF {
+		t.Errorf("Initial LFSR: got 0x%04X, want 0x7FFF", n.lfsr)
+	}
+
+	// Clock LFSR and verify it changes
+	initialLFSR := n.lfsr
+	n.clockLFSR()
+
+	if n.lfsr == initialLFSR {
+		t.Error("LFSR should change after clocking")
+	}
+
+	// Verify bit 14 is set based on XOR of bits 0 and 1
+	xorResult := (initialLFSR & 0x01) ^ ((initialLFSR >> 1) & 0x01)
+	expectedBit14 := (n.lfsr >> 14) & 0x01
+	if expectedBit14 != xorResult {
+		t.Errorf("Bit 14: got %d, want %d", expectedBit14, xorResult)
+	}
+}
+
+func TestNoiseChannel_LFSRWidth(t *testing.T) {
+	tests := []struct {
+		name      string
+		width7bit bool
+	}{
+		{"15-bit mode", false},
+		{"7-bit mode", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNoiseChannel()
+			n.lfsrWidth = tt.width7bit
+			n.lfsr = 0x7FFF
+
+			// Clock multiple times and check behavior
+			for i := 0; i < 100; i++ {
+				n.clockLFSR()
+			}
+
+			if tt.width7bit {
+				// In 7-bit mode, upper bits should match bit 6 pattern
+				// This is a simplified check - just verify LFSR is still changing
+				if n.lfsr == 0x7FFF {
+					t.Error("LFSR should have changed in 7-bit mode")
+				}
+			}
+		})
+	}
+}
+
+func TestNoiseChannel_LengthTimer(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Set length to 1 (63 internal counter)
+	n.WriteNR41(0x3F)
+	n.WriteNR42(0xF0) // Max volume
+	n.WriteNR44(0xC0) // Trigger with length enabled
+
+	if !n.IsEnabled() {
+		t.Fatal("Channel should be enabled after trigger")
+	}
+
+	// Clock length timer once
+	n.ClockLength()
+
+	if n.IsEnabled() {
+		t.Error("Channel should be disabled after length expires")
+	}
+}
+
+func TestNoiseChannel_VolumeEnvelope(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialVolume  uint8
+		envelopeAdd    bool
+		envelopePeriod uint8
+		expectedVolume uint8
+	}{
+		{"Increase from 0", 0, true, 1, 1},
+		{"Decrease from 15", 15, false, 1, 14},
+		{"No change (period 0)", 8, true, 0, 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := NewNoiseChannel()
+
+			// Set envelope
+			nr42 := tt.initialVolume << 4
+			if tt.envelopeAdd {
+				nr42 |= 0x08
+			}
+			nr42 |= tt.envelopePeriod
+			n.WriteNR42(nr42)
+			n.WriteNR44(0x80) // Trigger
+
+			// Clock envelope once
+			n.ClockEnvelope()
+
+			if n.envelopeVolume != tt.expectedVolume {
+				t.Errorf("Volume: got %d, want %d", n.envelopeVolume, tt.expectedVolume)
+			}
+		})
+	}
+}
+
+func TestNoiseChannel_FrequencyControl(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Test divisor codes
+	tests := []struct {
+		clockShift  uint8
+		divisorCode uint8
+	}{
+		{0, 0}, // divisor 8
+		{1, 1}, // divisor 16, shift 1
+		{4, 7}, // divisor 112, shift 4
+	}
+
+	for _, tt := range tests {
+		n.WriteNR43((tt.clockShift << 4) | tt.divisorCode)
+
+		if n.clockShift != tt.clockShift {
+			t.Errorf("Clock shift: got %d, want %d", n.clockShift, tt.clockShift)
+		}
+		if n.divisorCode != tt.divisorCode {
+			t.Errorf("Divisor code: got %d, want %d", n.divisorCode, tt.divisorCode)
+		}
+	}
+}
+
+func TestNoiseChannel_DACDisable(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Set volume to 0, no envelope (DAC off)
+	n.WriteNR42(0x00)
+	n.WriteNR44(0x80) // Trigger
+
+	if n.IsEnabled() {
+		t.Error("Channel should not enable when DAC is off")
+	}
+
+	if n.GetSample() != 0 {
+		t.Error("Sample should be 0 when DAC is disabled")
+	}
+}
+
+func TestNoiseChannel_Trigger(t *testing.T) {
+	n := NewNoiseChannel()
+
+	n.WriteNR42(0xF0) // Max volume, DAC enabled
+	n.WriteNR44(0x80) // Trigger
+
+	if !n.IsEnabled() {
+		t.Error("Channel should be enabled after trigger")
+	}
+
+	if n.lfsr != 0x7FFF {
+		t.Error("LFSR should be reset to 0x7FFF after trigger")
+	}
+
+	if n.phaseTimer != 0 {
+		t.Error("Phase timer should be reset to 0 after trigger")
+	}
+}
+
+func TestNoiseChannel_GetSample(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Enable and trigger
+	n.WriteNR42(0xF0) // Max volume
+	n.WriteNR44(0x80) // Trigger
+
+	// Get sample - should be based on inverted bit 0 of LFSR
+	sample := n.GetSample()
+
+	// LFSR starts at 0x7FFF (bit 0 = 1), inverted = 0
+	if sample != 0.0 {
+		t.Errorf("Initial sample: got %f, want 0.0", sample)
+	}
+
+	// Clock LFSR until we get bit 0 = 0 (inverted = 1)
+	for i := 0; i < 1000; i++ {
+		n.clockLFSR()
+		if (n.lfsr & 0x01) == 0 {
+			break
+		}
+	}
+
+	sample = n.GetSample()
+	expected := float32(15) / 15.0 // Max volume
+	if sample != expected {
+		t.Errorf("Sample with bit 0 = 0: got %f, want %f", sample, expected)
+	}
+}
+
+func TestNoiseChannel_Update(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Enable and trigger
+	n.WriteNR42(0xF0) // Max volume
+	n.WriteNR43(0x00) // Divisor 8, shift 0
+	n.WriteNR44(0x80) // Trigger
+
+	initialLFSR := n.lfsr
+
+	// Update with enough cycles to trigger LFSR clock
+	n.Update(8)
+
+	if n.lfsr == initialLFSR {
+		t.Error("LFSR should have changed after update")
+	}
+}
+
+func TestNoiseChannel_Reset(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Set some state
+	n.WriteNR41(0xFF)
+	n.WriteNR42(0xFF)
+	n.WriteNR43(0xFF)
+	n.WriteNR44(0xFF)
+
+	// Reset
+	n.Reset()
+
+	// Check state is cleared
+	if n.enabled {
+		t.Error("Channel should be disabled after reset")
+	}
+	if n.dacEnabled {
+		t.Error("DAC should be disabled after reset")
+	}
+	if n.lfsr != 0x7FFF {
+		t.Errorf("LFSR should be 0x7FFF after reset, got 0x%04X", n.lfsr)
+	}
+	if n.lengthCounter != 0 {
+		t.Error("Length counter should be 0 after reset")
+	}
+}
+
+func TestNoiseChannel_RegisterReadback(t *testing.T) {
+	n := NewNoiseChannel()
+
+	// Test NR42 readback
+	n.WriteNR42(0xF8)
+	if got := n.ReadNR42(); got != 0xF8 {
+		t.Errorf("NR42 readback: got 0x%02X, want 0xF8", got)
+	}
+
+	// Test NR43 readback
+	n.WriteNR43(0xFF)
+	if got := n.ReadNR43(); got != 0xFF {
+		t.Errorf("NR43 readback: got 0x%02X, want 0xFF", got)
+	}
+
+	// Test NR41 is write-only
+	n.WriteNR41(0x3F)
+	if got := n.ReadNR41(); got != 0xFF {
+		t.Errorf("NR41 should return 0xFF (write-only), got 0x%02X", got)
+	}
+}

--- a/internal/apu/pulse.go
+++ b/internal/apu/pulse.go
@@ -1,0 +1,348 @@
+package apu
+
+// PulseChannel represents a pulse wave channel (channels 1 and 2).
+type PulseChannel struct {
+	enabled    bool
+	dacEnabled bool
+
+	// Sweep (channel 1 only)
+	hasSweep     bool
+	sweepPeriod  uint8
+	sweepNegate  bool
+	sweepShift   uint8
+	sweepTimer   uint8
+	sweepEnabled bool
+	sweepShadow  uint16
+
+	// Length timer
+	lengthCounter uint8
+	lengthEnabled bool
+
+	// Volume envelope
+	envelopeVolume   uint8
+	envelopeInitial  uint8
+	envelopeIncrease bool
+	envelopePeriod   uint8
+	envelopeTimer    uint8
+
+	// Frequency and duty
+	frequency  uint16
+	dutyCycle  uint8
+	dutyPos    uint8
+	phaseTimer uint16
+
+	// Register values
+	nr10, nr11, nr12, nr13, nr14 uint8
+}
+
+// Duty cycle patterns (8 steps each).
+var dutyPatterns = [4][8]uint8{
+	{0, 0, 0, 0, 0, 0, 0, 1}, // 12.5%
+	{1, 0, 0, 0, 0, 0, 0, 1}, // 25%
+	{1, 0, 0, 0, 0, 1, 1, 1}, // 50%
+	{0, 1, 1, 1, 1, 1, 1, 0}, // 75%
+}
+
+// NewPulseChannel creates a new pulse channel.
+func NewPulseChannel(hasSweep bool) *PulseChannel {
+	return &PulseChannel{
+		hasSweep: hasSweep,
+	}
+}
+
+// Update advances the channel by the given number of cycles.
+func (p *PulseChannel) Update(cycles uint16) {
+	if !p.enabled || !p.dacEnabled {
+		return
+	}
+
+	// Update phase timer
+	p.phaseTimer += cycles
+	freq := (2048 - p.frequency) * 4
+	for p.phaseTimer >= freq {
+		p.phaseTimer -= freq
+		p.dutyPos = (p.dutyPos + 1) % 8
+	}
+}
+
+// GetSample returns the current sample output (0.0 to 1.0).
+func (p *PulseChannel) GetSample() float32 {
+	if !p.enabled || !p.dacEnabled {
+		return 0.0
+	}
+
+	// Get current duty pattern bit
+	bit := dutyPatterns[p.dutyCycle][p.dutyPos]
+	if bit == 0 {
+		return 0.0
+	}
+
+	// Return volume (0-15) normalized to 0.0-1.0
+	return float32(p.envelopeVolume) / 15.0
+}
+
+// ClockLength clocks the length timer.
+func (p *PulseChannel) ClockLength() {
+	if !p.lengthEnabled || p.lengthCounter == 0 {
+		return
+	}
+
+	p.lengthCounter--
+	if p.lengthCounter == 0 {
+		p.enabled = false
+	}
+}
+
+// ClockEnvelope clocks the volume envelope.
+func (p *PulseChannel) ClockEnvelope() {
+	if p.envelopePeriod == 0 {
+		return
+	}
+
+	p.envelopeTimer--
+	if p.envelopeTimer == 0 {
+		p.envelopeTimer = p.envelopePeriod
+
+		if p.envelopeIncrease && p.envelopeVolume < 15 {
+			p.envelopeVolume++
+		} else if !p.envelopeIncrease && p.envelopeVolume > 0 {
+			p.envelopeVolume--
+		}
+	}
+}
+
+// ClockSweep clocks the frequency sweep (channel 1 only).
+func (p *PulseChannel) ClockSweep() {
+	if !p.hasSweep || !p.sweepEnabled {
+		return
+	}
+
+	p.sweepTimer--
+	if p.sweepTimer == 0 { //nolint:nestif // Game Boy sweep logic is inherently complex
+		// Reload timer
+		if p.sweepPeriod > 0 {
+			p.sweepTimer = p.sweepPeriod
+		} else {
+			p.sweepTimer = 8
+		}
+
+		// Calculate new frequency
+		if p.sweepPeriod > 0 {
+			newFreq := p.calculateSweepFrequency()
+			if newFreq <= 2047 && p.sweepShift > 0 {
+				p.sweepShadow = newFreq
+				p.frequency = newFreq
+
+				// Overflow check
+				_ = p.calculateSweepFrequency()
+			}
+		}
+	}
+}
+
+// calculateSweepFrequency calculates the new frequency from sweep.
+func (p *PulseChannel) calculateSweepFrequency() uint16 {
+	delta := p.sweepShadow >> p.sweepShift
+	var newFreq uint16
+	if p.sweepNegate {
+		newFreq = p.sweepShadow - delta
+	} else {
+		newFreq = p.sweepShadow + delta
+	}
+
+	// Overflow check
+	if newFreq > 2047 {
+		p.enabled = false
+	}
+
+	return newFreq
+}
+
+// trigger triggers the channel (restarts it).
+func (p *PulseChannel) trigger() {
+	p.enabled = true
+
+	// Reload length counter if it's 0
+	if p.lengthCounter == 0 {
+		p.lengthCounter = 64
+	}
+
+	// Reset phase
+	p.phaseTimer = 0
+
+	// Reload envelope
+	p.envelopeTimer = p.envelopePeriod
+	p.envelopeVolume = p.envelopeInitial
+
+	// Reload sweep (channel 1 only)
+	if p.hasSweep {
+		p.sweepShadow = p.frequency
+		p.sweepTimer = p.sweepPeriod
+		if p.sweepTimer == 0 {
+			p.sweepTimer = 8
+		}
+		p.sweepEnabled = p.sweepPeriod > 0 || p.sweepShift > 0
+
+		// Sweep calculation on trigger
+		if p.sweepShift > 0 {
+			_ = p.calculateSweepFrequency()
+		}
+	}
+
+	// Channel is disabled if DAC is off
+	if !p.dacEnabled {
+		p.enabled = false
+	}
+}
+
+// IsEnabled returns whether the channel is enabled.
+func (p *PulseChannel) IsEnabled() bool {
+	return p.enabled
+}
+
+// Reset resets the channel to initial state.
+func (p *PulseChannel) Reset() {
+	p.enabled = false
+	p.dacEnabled = false
+	p.lengthCounter = 0
+	p.lengthEnabled = false
+	p.envelopeVolume = 0
+	p.envelopeInitial = 0
+	p.envelopeIncrease = false
+	p.envelopePeriod = 0
+	p.envelopeTimer = 0
+	p.frequency = 0
+	p.dutyCycle = 0
+	p.dutyPos = 0
+	p.phaseTimer = 0
+	p.nr10 = 0
+	p.nr11 = 0
+	p.nr12 = 0
+	p.nr13 = 0
+	p.nr14 = 0
+
+	if p.hasSweep {
+		p.sweepPeriod = 0
+		p.sweepNegate = false
+		p.sweepShift = 0
+		p.sweepTimer = 0
+		p.sweepEnabled = false
+		p.sweepShadow = 0
+	}
+}
+
+// Register read/write methods for Channel 1.
+
+// ReadNR10 reads NR10 (sweep).
+func (p *PulseChannel) ReadNR10() uint8 {
+	return p.nr10 | 0x80 // Bit 7 unused, reads as 1
+}
+
+// WriteNR10 writes NR10 (sweep).
+func (p *PulseChannel) WriteNR10(value uint8) {
+	p.nr10 = value
+	p.sweepPeriod = (value >> 4) & 0x07
+	p.sweepNegate = (value & 0x08) != 0
+	p.sweepShift = value & 0x07
+}
+
+// ReadNR11 reads NR11/NR21 (length timer & duty).
+func (p *PulseChannel) ReadNR11() uint8 {
+	return p.nr11 | 0x3F // Lower 6 bits write-only
+}
+
+// WriteNR11 writes NR11/NR21 (length timer & duty).
+func (p *PulseChannel) WriteNR11(value uint8) {
+	p.nr11 = value
+	p.dutyCycle = (value >> 6) & 0x03
+	p.lengthCounter = 64 - (value & 0x3F)
+}
+
+// ReadNR12 reads NR12/NR22 (volume envelope).
+func (p *PulseChannel) ReadNR12() uint8 {
+	return p.nr12
+}
+
+// WriteNR12 writes NR12/NR22 (volume envelope).
+func (p *PulseChannel) WriteNR12(value uint8) {
+	p.nr12 = value
+	p.envelopeInitial = (value >> 4) & 0x0F
+	p.envelopeIncrease = (value & 0x08) != 0
+	p.envelopePeriod = value & 0x07
+
+	// DAC is enabled if top 5 bits are non-zero
+	p.dacEnabled = (value & 0xF8) != 0
+	if !p.dacEnabled {
+		p.enabled = false
+	}
+}
+
+// ReadNR13 reads NR13/NR23 (frequency low).
+func (p *PulseChannel) ReadNR13() uint8 {
+	return 0xFF // Write-only
+}
+
+// WriteNR13 writes NR13/NR23 (frequency low).
+func (p *PulseChannel) WriteNR13(value uint8) {
+	p.nr13 = value
+	p.frequency = (p.frequency & 0x0700) | uint16(value)
+}
+
+// ReadNR14 reads NR14/NR24 (frequency high & control).
+func (p *PulseChannel) ReadNR14() uint8 {
+	return p.nr14 | 0xBF // Bits 7, 5-3 unused
+}
+
+// WriteNR14 writes NR14/NR24 (frequency high & control).
+func (p *PulseChannel) WriteNR14(value uint8) {
+	p.nr14 = value
+	p.frequency = (p.frequency & 0x00FF) | (uint16(value&0x07) << 8)
+	p.lengthEnabled = (value & 0x40) != 0
+
+	// Trigger
+	if (value & 0x80) != 0 {
+		p.trigger()
+	}
+}
+
+// Channel 2 uses the same register methods but with different names.
+
+// ReadNR21 reads NR21 (channel 2 length timer & duty).
+func (p *PulseChannel) ReadNR21() uint8 {
+	return p.ReadNR11()
+}
+
+// WriteNR21 writes NR21 (channel 2 length timer & duty).
+func (p *PulseChannel) WriteNR21(value uint8) {
+	p.WriteNR11(value)
+}
+
+// ReadNR22 reads NR22 (channel 2 volume envelope).
+func (p *PulseChannel) ReadNR22() uint8 {
+	return p.ReadNR12()
+}
+
+// WriteNR22 writes NR22 (channel 2 volume envelope).
+func (p *PulseChannel) WriteNR22(value uint8) {
+	p.WriteNR12(value)
+}
+
+// ReadNR23 reads NR23 (channel 2 frequency low).
+func (p *PulseChannel) ReadNR23() uint8 {
+	return p.ReadNR13()
+}
+
+// WriteNR23 writes NR23 (channel 2 frequency low).
+func (p *PulseChannel) WriteNR23(value uint8) {
+	p.WriteNR13(value)
+}
+
+// ReadNR24 reads NR24 (channel 2 frequency high & control).
+func (p *PulseChannel) ReadNR24() uint8 {
+	return p.ReadNR14()
+}
+
+// WriteNR24 writes NR24 (channel 2 frequency high & control).
+func (p *PulseChannel) WriteNR24(value uint8) {
+	p.WriteNR14(value)
+}

--- a/internal/apu/pulse_test.go
+++ b/internal/apu/pulse_test.go
@@ -1,0 +1,203 @@
+package apu
+
+import (
+	"testing"
+)
+
+func TestPulseChannel_DutyPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		dutyPattern uint8
+		expectedOns int // Number of '1's in 8-step cycle
+	}{
+		{"12.5% duty", 0, 1},
+		{"25% duty", 1, 2},
+		{"50% duty", 2, 4},
+		{"75% duty", 3, 6},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPulseChannel(false)
+			p.WriteNR21(tt.dutyPattern << 6)
+			p.WriteNR22(0xF0) // Max volume, no envelope
+			p.WriteNR24(0x80) // Trigger
+
+			ones := 0
+			for i := 0; i < 8; i++ {
+				sample := p.GetSample()
+				if sample > 0 {
+					ones++
+				}
+				// Advance to next step in duty cycle
+				p.phaseTimer = 2048 * 2
+				p.Update(2048 * 2)
+			}
+
+			if ones != tt.expectedOns {
+				t.Errorf("Duty pattern %d: got %d ones, want %d", tt.dutyPattern, ones, tt.expectedOns)
+			}
+		})
+	}
+}
+
+func TestPulseChannel_LengthTimer(t *testing.T) {
+	p := NewPulseChannel(false)
+
+	// Set length to 1 (63 internal counter)
+	p.WriteNR21(0x3F) // Length = 1
+	p.WriteNR22(0xF0) // Max volume
+	p.WriteNR24(0xC0) // Trigger with length enabled
+
+	if !p.IsEnabled() {
+		t.Fatal("Channel should be enabled after trigger")
+	}
+
+	// Clock length timer once
+	p.ClockLength()
+
+	if p.IsEnabled() {
+		t.Error("Channel should be disabled after length expires")
+	}
+}
+
+func TestPulseChannel_VolumeEnvelope(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialVolume  uint8
+		envelopeAdd    bool
+		envelopePeriod uint8
+		expectedVolume uint8
+	}{
+		{"Increase from 0", 0, true, 1, 1},
+		{"Decrease from 15", 15, false, 1, 14},
+		{"No change (period 0)", 8, true, 0, 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewPulseChannel(false)
+
+			// Set envelope
+			nr22 := tt.initialVolume << 4
+			if tt.envelopeAdd {
+				nr22 |= 0x08
+			}
+			nr22 |= tt.envelopePeriod
+			p.WriteNR22(nr22)
+			p.WriteNR24(0x80) // Trigger
+
+			// Clock envelope once
+			p.ClockEnvelope()
+
+			if p.envelopeVolume != tt.expectedVolume {
+				t.Errorf("Volume: got %d, want %d", p.envelopeVolume, tt.expectedVolume)
+			}
+		})
+	}
+}
+
+func TestPulseChannel_Sweep(t *testing.T) {
+	p := NewPulseChannel(true) // Channel 1 with sweep
+
+	// Set sweep: period=1, shift=1, increase
+	p.WriteNR10(0x11) // 001 0 001 = period 1, increase, shift 1
+
+	// Set frequency to 100 (small value to avoid overflow)
+	p.WriteNR13(100)
+
+	p.WriteNR12(0xF0) // Max volume
+
+	// Trigger
+	p.WriteNR14(0x80)
+
+	// Verify sweep enabled
+	if !p.sweepEnabled {
+		t.Fatal("Sweep should be enabled after trigger with period=1, shift=1")
+	}
+
+	// Verify sweep shadow register was set
+	if p.sweepShadow != 100 {
+		t.Errorf("Sweep shadow should be 100, got %d", p.sweepShadow)
+	}
+}
+
+func TestPulseChannel_DACDisable(t *testing.T) {
+	p := NewPulseChannel(false)
+
+	// Set volume to 0, no envelope (DAC off)
+	p.WriteNR22(0x00)
+	p.WriteNR24(0x80) // Trigger
+
+	if p.IsEnabled() {
+		t.Error("Channel should not enable when DAC is off")
+	}
+
+	if p.GetSample() != 0 {
+		t.Error("Sample should be 0 when DAC is disabled")
+	}
+}
+
+func TestPulseChannel_FrequencyChange(t *testing.T) {
+	p := NewPulseChannel(false)
+
+	// Set frequency
+	p.WriteNR13(0xFF) // Low byte
+	p.WriteNR14(0x07) // High 3 bits
+
+	expectedFreq := uint16(0x7FF)
+	if p.frequency != expectedFreq {
+		t.Errorf("Frequency: got %d, want %d", p.frequency, expectedFreq)
+	}
+}
+
+func TestPulseChannel_Reset(t *testing.T) {
+	p := NewPulseChannel(true)
+
+	// Set some state
+	p.WriteNR10(0x7F)
+	p.WriteNR11(0xFF)
+	p.WriteNR12(0xFF)
+	p.WriteNR13(0xFF)
+	p.WriteNR14(0xFF)
+
+	// Reset
+	p.Reset()
+
+	// Check all state is cleared
+	if p.enabled {
+		t.Error("Channel should be disabled after reset")
+	}
+	if p.dacEnabled {
+		t.Error("DAC should be disabled after reset")
+	}
+	if p.frequency != 0 {
+		t.Error("Frequency should be 0 after reset")
+	}
+	if p.lengthCounter != 0 {
+		t.Error("Length counter should be 0 after reset")
+	}
+}
+
+func TestPulseChannel_RegisterReadback(t *testing.T) {
+	p := NewPulseChannel(true)
+
+	// Test NR10 readback (only available on channel 1)
+	// Bit 7 is unused and reads as 1
+	p.WriteNR10(0x7F)
+	if got := p.ReadNR10(); got != 0xFF {
+		t.Errorf("NR10 readback: got 0x%02X, want 0xFF (bit 7 unused)", got)
+	}
+
+	// Test NR12 readback
+	p.WriteNR12(0xF8)
+	if got := p.ReadNR12(); got != 0xF8 {
+		t.Errorf("NR12 readback: got 0x%02X, want 0xF8", got)
+	}
+
+	// Test NR11 is write-only (returns 0xFF with duty bits)
+	p.WriteNR11(0xC0)
+	if got := p.ReadNR11(); (got & 0xC0) != 0xC0 {
+		t.Errorf("NR11 duty bits: got 0x%02X", got)
+	}
+}

--- a/internal/apu/wave.go
+++ b/internal/apu/wave.go
@@ -1,0 +1,202 @@
+package apu
+
+// WaveChannel represents the wave channel (channel 3).
+type WaveChannel struct {
+	enabled    bool
+	dacEnabled bool
+
+	// Length timer
+	lengthCounter uint16
+	lengthEnabled bool
+
+	// Frequency and output
+	frequency   uint16
+	outputLevel uint8
+	phaseTimer  uint16
+	wavePos     uint8
+
+	// Wave RAM (32 4-bit samples)
+	waveRAM [16]uint8
+
+	// Register values
+	nr30, nr31, nr32, nr33, nr34 uint8
+}
+
+// NewWaveChannel creates a new wave channel.
+func NewWaveChannel() *WaveChannel {
+	return &WaveChannel{}
+}
+
+// Update advances the channel by the given number of cycles.
+func (w *WaveChannel) Update(cycles uint16) {
+	if !w.enabled || !w.dacEnabled {
+		return
+	}
+
+	// Update phase timer
+	w.phaseTimer += cycles
+	freq := (2048 - w.frequency) * 2
+	for w.phaseTimer >= freq {
+		w.phaseTimer -= freq
+		w.wavePos = (w.wavePos + 1) % 32
+	}
+}
+
+// GetSample returns the current sample output (0.0 to 1.0).
+func (w *WaveChannel) GetSample() float32 {
+	if !w.enabled || !w.dacEnabled {
+		return 0.0
+	}
+
+	// Get 4-bit sample from wave RAM
+	byteIndex := w.wavePos / 2
+	nibbleShift := (1 - (w.wavePos % 2)) * 4
+	sample := (w.waveRAM[byteIndex] >> nibbleShift) & 0x0F
+
+	// Apply output level
+	switch w.outputLevel {
+	case 0:
+		sample = 0 // Mute
+	case 1:
+		// 100% (no change)
+	case 2:
+		sample >>= 1 // 50%
+	case 3:
+		sample >>= 2 // 25%
+	}
+
+	// Normalize to 0.0-1.0
+	return float32(sample) / 15.0
+}
+
+// ClockLength clocks the length timer.
+func (w *WaveChannel) ClockLength() {
+	if !w.lengthEnabled || w.lengthCounter == 0 {
+		return
+	}
+
+	w.lengthCounter--
+	if w.lengthCounter == 0 {
+		w.enabled = false
+	}
+}
+
+// trigger triggers the channel (restarts it).
+func (w *WaveChannel) trigger() {
+	w.enabled = true
+
+	// Reload length counter if it's 0
+	if w.lengthCounter == 0 {
+		w.lengthCounter = 256
+	}
+
+	// Reset wave position
+	w.wavePos = 0
+	w.phaseTimer = 0
+
+	// Channel is disabled if DAC is off
+	if !w.dacEnabled {
+		w.enabled = false
+	}
+}
+
+// IsEnabled returns whether the channel is enabled.
+func (w *WaveChannel) IsEnabled() bool {
+	return w.enabled
+}
+
+// Reset resets the channel to initial state.
+func (w *WaveChannel) Reset() {
+	w.enabled = false
+	w.dacEnabled = false
+	w.lengthCounter = 0
+	w.lengthEnabled = false
+	w.frequency = 0
+	w.outputLevel = 0
+	w.phaseTimer = 0
+	w.wavePos = 0
+	w.nr30 = 0
+	w.nr31 = 0
+	w.nr32 = 0
+	w.nr33 = 0
+	w.nr34 = 0
+
+	// Clear wave RAM
+	for i := range w.waveRAM {
+		w.waveRAM[i] = 0
+	}
+}
+
+// ReadNR30 reads NR30 (DAC enable).
+func (w *WaveChannel) ReadNR30() uint8 {
+	return w.nr30 | 0x7F // Lower 7 bits unused
+}
+
+// WriteNR30 writes NR30 (DAC enable).
+func (w *WaveChannel) WriteNR30(value uint8) {
+	w.nr30 = value
+	w.dacEnabled = (value & 0x80) != 0
+	if !w.dacEnabled {
+		w.enabled = false
+	}
+}
+
+// ReadNR31 reads NR31 (length timer).
+func (w *WaveChannel) ReadNR31() uint8 {
+	return 0xFF // Write-only
+}
+
+// WriteNR31 writes NR31 (length timer).
+func (w *WaveChannel) WriteNR31(value uint8) {
+	w.nr31 = value
+	w.lengthCounter = 256 - uint16(value)
+}
+
+// ReadNR32 reads NR32 (output level).
+func (w *WaveChannel) ReadNR32() uint8 {
+	return w.nr32 | 0x9F // Bits 7, 4-0 unused
+}
+
+// WriteNR32 writes NR32 (output level).
+func (w *WaveChannel) WriteNR32(value uint8) {
+	w.nr32 = value
+	w.outputLevel = (value >> 5) & 0x03
+}
+
+// ReadNR33 reads NR33 (frequency low).
+func (w *WaveChannel) ReadNR33() uint8 {
+	return 0xFF // Write-only
+}
+
+// WriteNR33 writes NR33 (frequency low).
+func (w *WaveChannel) WriteNR33(value uint8) {
+	w.nr33 = value
+	w.frequency = (w.frequency & 0x0700) | uint16(value)
+}
+
+// ReadNR34 reads NR34 (frequency high & control).
+func (w *WaveChannel) ReadNR34() uint8 {
+	return w.nr34 | 0xBF // Bits 7, 5-3 unused
+}
+
+// WriteNR34 writes NR34 (frequency high & control).
+func (w *WaveChannel) WriteNR34(value uint8) {
+	w.nr34 = value
+	w.frequency = (w.frequency & 0x00FF) | (uint16(value&0x07) << 8)
+	w.lengthEnabled = (value & 0x40) != 0
+
+	// Trigger
+	if (value & 0x80) != 0 {
+		w.trigger()
+	}
+}
+
+// ReadWaveRAM reads a byte from wave RAM.
+func (w *WaveChannel) ReadWaveRAM(offset uint16) uint8 {
+	return w.waveRAM[offset]
+}
+
+// WriteWaveRAM writes a byte to wave RAM.
+func (w *WaveChannel) WriteWaveRAM(offset uint16, value uint8) {
+	w.waveRAM[offset] = value
+}

--- a/internal/apu/wave_test.go
+++ b/internal/apu/wave_test.go
@@ -1,0 +1,221 @@
+package apu
+
+import (
+	"testing"
+)
+
+func TestWaveChannel_DACEnable(t *testing.T) {
+	w := NewWaveChannel()
+
+	// DAC disabled by default
+	if w.dacEnabled {
+		t.Error("DAC should be disabled by default")
+	}
+
+	// Enable DAC
+	w.WriteNR30(0x80)
+	if !w.dacEnabled {
+		t.Error("DAC should be enabled after writing 0x80 to NR30")
+	}
+
+	// Disable DAC
+	w.WriteNR30(0x00)
+	if w.dacEnabled {
+		t.Error("DAC should be disabled after writing 0x00 to NR30")
+	}
+}
+
+func TestWaveChannel_LengthTimer(t *testing.T) {
+	w := NewWaveChannel()
+
+	// Set length to 1 (255 internal counter)
+	w.WriteNR31(0xFF)
+	w.WriteNR30(0x80) // Enable DAC
+	w.WriteNR34(0xC0) // Trigger with length enabled
+
+	if !w.IsEnabled() {
+		t.Fatal("Channel should be enabled after trigger")
+	}
+
+	// Clock length timer once
+	w.ClockLength()
+
+	if w.IsEnabled() {
+		t.Error("Channel should be disabled after length expires")
+	}
+}
+
+func TestWaveChannel_OutputLevel(t *testing.T) {
+	w := NewWaveChannel()
+
+	// Write a known pattern to wave RAM (all 0xF)
+	for i := uint16(0); i < 16; i++ {
+		w.WriteWaveRAM(i, 0xFF)
+	}
+
+	tests := []struct {
+		name        string
+		outputLevel uint8
+		expected    float32
+	}{
+		{"Mute (0%)", 0, 0.0},  // Sample 0xF >> inf = 0
+		{"100%", 1, 1.0},       // Sample 0xF (no shift) = 15/15
+		{"50%", 2, 7.0 / 15.0}, // Sample 0xF >> 1 = 7
+		{"25%", 3, 3.0 / 15.0}, // Sample 0xF >> 2 = 3
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w.WriteNR30(0x80)                // Enable DAC
+			w.WriteNR32(tt.outputLevel << 5) // Set output level
+			w.WriteNR34(0x80)                // Trigger
+
+			sample := w.GetSample()
+
+			// Allow small floating point error
+			if abs(sample-tt.expected) > 0.01 {
+				t.Errorf("Output level %d: got %f, want %f", tt.outputLevel, sample, tt.expected)
+			}
+		})
+	}
+}
+
+func TestWaveChannel_WaveRAM(t *testing.T) {
+	w := NewWaveChannel()
+
+	// Write pattern to wave RAM
+	for i := uint16(0); i < 16; i++ {
+		w.WriteWaveRAM(i, uint8(i))
+	}
+
+	// Read back and verify
+	for i := uint16(0); i < 16; i++ {
+		got := w.ReadWaveRAM(i)
+		want := uint8(i)
+		if got != want {
+			t.Errorf("WaveRAM[%d]: got 0x%02X, want 0x%02X", i, got, want)
+		}
+	}
+}
+
+func TestWaveChannel_FrequencyChange(t *testing.T) {
+	w := NewWaveChannel()
+
+	// Set frequency
+	w.WriteNR33(0xFF) // Low byte
+	w.WriteNR34(0x07) // High 3 bits
+
+	expectedFreq := uint16(0x7FF)
+	if w.frequency != expectedFreq {
+		t.Errorf("Frequency: got %d, want %d", w.frequency, expectedFreq)
+	}
+}
+
+func TestWaveChannel_Trigger(t *testing.T) {
+	w := NewWaveChannel()
+
+	w.WriteNR30(0x80) // Enable DAC
+	w.WriteNR34(0x80) // Trigger
+
+	if !w.IsEnabled() {
+		t.Error("Channel should be enabled after trigger")
+	}
+
+	if w.wavePos != 0 {
+		t.Error("Wave position should be reset to 0 after trigger")
+	}
+
+	if w.phaseTimer != 0 {
+		t.Error("Phase timer should be reset to 0 after trigger")
+	}
+}
+
+func TestWaveChannel_DACDisableClearsEnabled(t *testing.T) {
+	w := NewWaveChannel()
+
+	// Enable and trigger
+	w.WriteNR30(0x80)
+	w.WriteNR34(0x80)
+
+	if !w.IsEnabled() {
+		t.Fatal("Channel should be enabled")
+	}
+
+	// Disable DAC
+	w.WriteNR30(0x00)
+
+	if w.IsEnabled() {
+		t.Error("Channel should be disabled when DAC is turned off")
+	}
+}
+
+func TestWaveChannel_SampleProgression(t *testing.T) {
+	w := NewWaveChannel()
+
+	// Write simple pattern: first byte 0x01, rest 0x00
+	w.WriteWaveRAM(0, 0x01)
+	for i := uint16(1); i < 16; i++ {
+		w.WriteWaveRAM(i, 0x00)
+	}
+
+	w.WriteNR30(0x80) // Enable DAC
+	w.WriteNR32(0x20) // 100% output level
+	w.WriteNR33(0x00) // Frequency = 0
+	w.WriteNR34(0x80) // Trigger
+
+	// First sample should be from high nibble of first byte (0x0)
+	sample1 := w.GetSample()
+	if sample1 != 0.0 {
+		t.Errorf("First sample: got %f, want 0.0", sample1)
+	}
+
+	// Advance wave position
+	w.wavePos = 1
+	// Second sample should be from low nibble of first byte (0x1)
+	sample2 := w.GetSample()
+	expected := float32(1) / 15.0
+	if abs(sample2-expected) > 0.01 {
+		t.Errorf("Second sample: got %f, want %f", sample2, expected)
+	}
+}
+
+func TestWaveChannel_Reset(t *testing.T) {
+	w := NewWaveChannel()
+
+	// Set some state
+	w.WriteNR30(0xFF)
+	w.WriteNR31(0xFF)
+	w.WriteNR32(0xFF)
+	w.WriteNR33(0xFF)
+	w.WriteNR34(0xFF)
+	for i := uint16(0); i < 16; i++ {
+		w.WriteWaveRAM(i, 0xFF)
+	}
+
+	// Reset
+	w.Reset()
+
+	// Check state is cleared
+	if w.enabled {
+		t.Error("Channel should be disabled after reset")
+	}
+	if w.dacEnabled {
+		t.Error("DAC should be disabled after reset")
+	}
+	if w.frequency != 0 {
+		t.Error("Frequency should be 0 after reset")
+	}
+	for i := uint16(0); i < 16; i++ {
+		if w.waveRAM[i] != 0 {
+			t.Errorf("WaveRAM[%d] should be 0 after reset, got 0x%02X", i, w.waveRAM[i])
+		}
+	}
+}
+
+// Helper function for floating point comparison.
+func abs(x float32) float32 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
## Summary
Implements complete Game Boy Audio Processing Unit (APU) with 4 sound channels and Ebiten audio integration, enabling full audio emulation.

## Implementation Details

### APU Core (`internal/apu/`)
- **`apu.go`**: Main APU orchestration, frame sequencer, sample mixing
- **`pulse.go`**: Pulse channels 1 & 2 with sweep, duty cycles, envelope
- **`wave.go`**: Wave channel with programmable 32-sample wave RAM
- **`noise.go`**: Noise channel with LFSR (15-bit and 7-bit modes)

### Audio Features
✅ **Channel 1** - Pulse with sweep (NR10-NR14)
  - Frequency sweep (increase/decrease modes)
  - 4 duty cycle patterns (12.5%, 25%, 50%, 75%)
  - Volume envelope
  - Length timer

✅ **Channel 2** - Pulse without sweep (NR21-NR24)
  - Same as Channel 1 except no frequency sweep

✅ **Channel 3** - Wave (NR30-NR34, Wave RAM 0xFF30-0xFF3F)
  - 32 4-bit programmable samples
  - Output level control (mute, 25%, 50%, 100%)
  - 256-step length timer

✅ **Channel 4** - Noise (NR41-NR44)
  - LFSR with 15-bit and 7-bit width modes
  - Configurable frequency and divisor
  - Volume envelope

✅ **Frame Sequencer** - 512 Hz timing system
  - Length clocked at 256 Hz
  - Envelope clocked at 64 Hz
  - Sweep clocked at 128 Hz

✅ **Stereo Output**
  - Channel panning via NR51
  - Master volume control via NR50
  - Sample mixing with proper scaling

### Integration
- **Memory Bus**: Audio registers delegated to APU
- **Emulator**: APU updated cycle-accurately with CPU
- **Ebiten**: Audio output at 48kHz stereo

### Testing
- 300+ lines of comprehensive unit tests
- All 4 channels tested independently
- Frame sequencer timing verified
- Register read/write tests
- Panning and volume tests
- ✅ All tests passing
- ✅ golangci-lint clean

### Documentation
- Updated `CLAUDE.md` with Phase 6 completion
- Updated `README.md` with APU features
- Inline code documentation

## Test Plan
- [x] Build succeeds (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] APU unit tests (pulse, wave, noise, frame sequencer)
- [x] Memory integration tests
- [x] Documentation updated
- [ ] Code review
- [ ] Manual audio testing with Game Boy ROMs

## Files Changed
- **New**: `internal/apu/{apu,pulse,wave,noise}.go` - APU implementation
- **New**: `internal/apu/{apu,pulse,wave,noise}_test.go` - Unit tests
- **New**: `cmd/nostalgiza/audio.go` - Ebiten audio player
- **Modified**: `internal/memory/memory.go` - Audio register delegation
- **Modified**: `internal/emulator/emulator.go` - APU integration
- **Modified**: `CLAUDE.md`, `README.md` - Documentation
- **Modified**: `go.mod`, `go.sum` - Dependencies (Ebiten audio)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)