### PR TITLE
Fix Noise Channel LFSR Implementation

### DIFF
--- a/docs/08-audio.md
+++ b/docs/08-audio.md
@@ -212,10 +212,10 @@ LFSR width:
 
 ### Linear Feedback Shift Register (LFSR)
 Generates pseudo-random bit pattern:
-1. XOR bits 0 and 1
-2. Shift register right
-3. Place XOR result in bit 14 (and bit 6 if 7-bit mode)
-4. Output bit 0
+1. XNOR bits 0 and 1 (inverted XOR: identical bits → 1, different bits → 0)
+2. Place XNOR result in bit 15 (and bit 7 if 7-bit mode)
+3. Shift register right (XNOR result ends in bit 14, or bit 6 in 7-bit mode)
+4. Output inverted bit 0
 
 ## APU Timing
 


### PR DESCRIPTION
## Summary
- Fixed noise channel LFSR initialization and algorithm to match Pan Docs specification
- Changed LFSR initialization from `0x7FFF` to `0` (per Pan Docs)
- Corrected LFSR algorithm to use XNOR instead of XOR
- Fixed bit placement: XNOR result now placed in bit 15 before shift (ends in bit 14 after)
- Fixed 7-bit mode to affect bit 7 before shift (ends in bit 6 after)
- Updated all tests to verify correct behavior

## Technical Details
The previous implementation had several issues:
1. **Initialization**: Started at `0x7FFF` instead of `0`
2. **Logic**: Used XOR instead of XNOR for feedback
3. **Bit placement**: Placed result directly in bit 14 instead of bit 15 pre-shift
4. **7-bit mode**: Affected bit 6 instead of bit 7 pre-shift

The corrected implementation now properly generates pseudo-random noise patterns matching Game Boy hardware behavior.

## Test Plan
- [x] All existing tests updated and passing
- [x] LFSR initialization verified
- [x] LFSR clocking algorithm verified
- [x] 7-bit and 15-bit modes verified
- [x] Sample generation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)