### PR TITLE
Verify serial output timing with Blargg tests

### DIFF
--- a/cmd/nostalgiza/testrom_test.go
+++ b/cmd/nostalgiza/testrom_test.go
@@ -35,7 +35,7 @@ func TestBlarggCPUInstrs(t *testing.T) {
 		skipReason string
 	}{
 		{"01-special", "cpu_instrs/individual/01-special.gb", false, ""},
-		{"02-interrupts", "cpu_instrs/individual/02-interrupts.gb", true, "requires interrupt support (Phase 4)"},
+		{"02-interrupts", "cpu_instrs/individual/02-interrupts.gb", false, ""},
 		{"03-op sp,hl", "cpu_instrs/individual/03-op sp,hl.gb", false, ""},
 		{"04-op r,imm", "cpu_instrs/individual/04-op r,imm.gb", false, ""},
 		{"05-op rp", "cpu_instrs/individual/05-op rp.gb", false, ""},


### PR DESCRIPTION
## Summary
- Verified serial output timing implementation works correctly
- Enabled 02-interrupts test (interrupts now implemented in Phase 4)
- All 11 Blargg CPU instruction tests pass successfully
- Tests complete quickly (<1 second) with proper completion detection

## Test Results

All Blargg CPU instruction tests pass:
```
=== RUN   TestBlarggCPUInstrs
--- PASS: TestBlarggCPUInstrs (0.61s)
    --- PASS: TestBlarggCPUInstrs/01-special (0.03s)
    --- PASS: TestBlarggCPUInstrs/02-interrupts (0.01s)
    --- PASS: TestBlarggCPUInstrs/03-op_sp,hl (0.03s)
    --- PASS: TestBlarggCPUInstrs/04-op_r,imm (0.03s)
    --- PASS: TestBlarggCPUInstrs/05-op_rp (0.04s)
    --- PASS: TestBlarggCPUInstrs/06-ld_r,r (0.01s)
    --- PASS: TestBlarggCPUInstrs/07-jr,jp,call,ret,rst (0.01s)
    --- PASS: TestBlarggCPUInstrs/08-misc_instrs (0.01s)
    --- PASS: TestBlarggCPUInstrs/09-op_r,r (0.11s)
    --- PASS: TestBlarggCPUInstrs/10-bit_ops (0.16s)
    --- PASS: TestBlarggCPUInstrs/11-op_a,(hl) (0.19s)
```

## Verification

✅ **Completion detection works correctly** - All tests properly detect "Passed" output  
✅ **Timeouts are reasonable** - All tests complete well below 30s timeout  
✅ **Serial output timing is adequate** - Checking after `RunCycles()` doesn't impact compatibility

## Changes
- Removed skip flag from `02-interrupts` test (interrupts implemented in PR #23)

Closes #20

## Test Plan
- [x] All Blargg CPU instruction tests pass
- [x] Tests complete with reasonable timeouts
- [x] Serial output detection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)